### PR TITLE
feat(MT-4270): support for preventing calls in BaseService.php from throwing an exception when the request is a non-200 status

### DIFF
--- a/src/ResourceServiceOptions.php
+++ b/src/ResourceServiceOptions.php
@@ -6,8 +6,23 @@ class ResourceServiceOptions
 {
     public bool $keepRawResponse;
 
+    public bool $manuallyHandleRequestErrors;
+
+    public function __construct()
+    {
+        $this->keepRawResponse = false;
+        $this->manuallyHandleRequestErrors = false;
+    }
+
     public function withRawResponse(): void
     {
         $this->keepRawResponse = true;
     }
+
+    public function withManuallyHandledRequestErrors(): void
+    {
+        $this->manuallyHandleRequestErrors = true;
+    }
+
+
 }

--- a/src/Services/Concerns/HandlesApiErrors.php
+++ b/src/Services/Concerns/HandlesApiErrors.php
@@ -43,11 +43,10 @@ trait HandlesApiErrors
                 return Exceptions\AuthorizationException::factory($response);
             case 404:
             case 410:
+            case 429:
                 return Exceptions\NotFoundException::factory($response);
             case 409:
                 return Exceptions\ConflictException::factory($response);
-            case 429:
-                return Exceptions\NotFoundException::factory($response);
             case 500:
             case 502:
             case 503:


### PR DESCRIPTION
feat(MT-4270): support for preventing calls in BaseService.php from throwing an exception when the request is a non-200 status